### PR TITLE
Update HTTP retry policy

### DIFF
--- a/Classes/MSAISender.m
+++ b/Classes/MSAISender.m
@@ -102,7 +102,7 @@ static NSInteger const statusCodeBadRequest = 400;
     NSInteger statusCode = [operation.response statusCode];
 
     if([self shouldDeleteDataWithStatusCode:statusCode]) {
-      // We should delete data if it has been succesfully sent (200/202) or if its values have not been accepted (400)
+      //we delete data that was either sent successfully or if we have a non-recoverable error
       MSAILog(@"Sent data with status code: %ld", (long) statusCode);
       MSAILog(@"Response data:\n%@", [NSJSONSerialization JSONObjectWithData:responseData options:0 error:nil]);
       
@@ -146,10 +146,12 @@ static NSInteger const statusCodeBadRequest = 400;
   return request;
 }
 
+//some status codes represent recoverable error codes
+//we try sending again some point later
 - (BOOL)shouldDeleteDataWithStatusCode:(NSInteger)statusCode {
-  NSArray *acceptableStatusCodes = @[@429, @408, @500, @503, @511];
+  NSArray *recoverableStatusCodes = @[@429, @408, @500, @503, @511];
 
-  return ![acceptableStatusCodes containsObject:@(statusCode)];
+  return ![recoverableStatusCodes containsObject:@(statusCode)];
 }
 
 #pragma mark - Getter/Setter

--- a/Classes/MSAISender.m
+++ b/Classes/MSAISender.m
@@ -147,8 +147,9 @@ static NSInteger const statusCodeBadRequest = 400;
 }
 
 - (BOOL)shouldDeleteDataWithStatusCode:(NSInteger)statusCode {
-  
-  return (statusCode >= statusCodeOK && statusCode <= statusCodeAccepted) || statusCode == statusCodeBadRequest;
+  NSArray *acceptableStatusCodes = @[@429, @408, @500, @503, @511];
+
+  return ![acceptableStatusCodes containsObject:@(statusCode)];
 }
 
 #pragma mark - Getter/Setter

--- a/Support/ApplicationInsightsTests/MSAISenderTests.m
+++ b/Support/ApplicationInsightsTests/MSAISenderTests.m
@@ -72,10 +72,10 @@
 - (void)testDeleteDataWithStatusCodeWorks{
   
   for(NSInteger statusCode = 100; statusCode <= 510; statusCode++){
-    if((statusCode >= 200 && statusCode <= 202) || statusCode == 400){
-      assertThatBool([_sut shouldDeleteDataWithStatusCode:statusCode], isTrue());
-    }else{
+    if((statusCode == 429) || (statusCode == 408) || (statusCode == 500) || (statusCode == 503) || (statusCode == 511)) {
       assertThatBool([_sut shouldDeleteDataWithStatusCode:statusCode], isFalse());
+    }else{
+      assertThatBool([_sut shouldDeleteDataWithStatusCode:statusCode], isTrue());
     }
   }
 }


### PR DESCRIPTION
We now only retry after HTTP status code 429, 408, 500, 503, and 511.