### PR TITLE
Extend automatic lifecycle tracking

### DIFF
--- a/Classes/MSAIApplicationInsights.h
+++ b/Classes/MSAIApplicationInsights.h
@@ -124,6 +124,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)setTelemetryManagerDisabled:(BOOL)telemetryManagerDisabled;
 
+@property (nonatomic, getter=isAutoLifeCycleTrackingDisabled) BOOL autoLifeCycleTrackingDisabled;
+
++ (void)setAutoLifeCycleTrackingDisabled:(BOOL)autoLifeCycleTrackingDisabled;
+
 /**
  * Flag that determines whether collecting page views automatically should be disabled.
  * If YES, auto page view collection is disabled.
@@ -133,14 +137,14 @@ NS_ASSUME_NONNULL_BEGIN
  * @default NO
  * @warning This property needs to be set before calling `start`
  */
-@property (nonatomic, getter = isAutoPageViewTrackingDisabled) BOOL autoPageViewTrackingDisabled;
+@property (nonatomic, getter = isAutoPageViewTrackingDisabled) BOOL autoPageViewTrackingDisabled __deprecated_msg("Use autoLifeCycleTrackingDisabled instead!");
 
 /**
  *  Enable (NO) or disable (YES) auto collection of page views. This should be called before `start`.
  *
  *  @param autoPageViewTrackingDisabled Flag which determines whether the page view collection should be disabled
  */
-+ (void)setAutoPageViewTrackingDisabled:(BOOL)autoPageViewTrackingDisabled;
++ (void)setAutoPageViewTrackingDisabled:(BOOL)autoPageViewTrackingDisabled __deprecated_msg("Use setAutoLifeCycleTrackingDisabled:w instead!");
 
 #endif /* MSAI_FEATURE_TELEMETRY */
 

--- a/Classes/MSAIApplicationInsights.m
+++ b/Classes/MSAIApplicationInsights.m
@@ -62,8 +62,11 @@ NSString *const kMSAIInstrumentationKey = @"MSAIInstrumentationKey";
 #endif /* MSAI_FEATURE_CRASH_REPORTER */
 #if MSAI_FEATURE_TELEMETRY
     _telemetryManagerDisabled = NO;
+    _autoPageViewTrackingDisabled = NO;
+    _autoLifeCycleTrackingDisabled = NO;
 #endif /* MSAI_FEATURE_TELEMETRY */
     _appStoreEnvironment = NO;
+    _autoSessionManagementDisabled = NO;
     _startManagerIsInvoked = NO;
     
     msai_isAppStoreEnvironment();

--- a/Classes/MSAIApplicationInsights.m
+++ b/Classes/MSAIApplicationInsights.m
@@ -122,10 +122,22 @@ NSString *const kMSAIInstrumentationKey = @"MSAIInstrumentationKey";
   
 #if MSAI_FEATURE_TELEMETRY
   if (![self isTelemetryManagerDisabled]) {
-    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if([self isAutoPageViewTrackingDisabled]){
       MSAILog(@"INFO: Auto page views disabled");
       [MSAITelemetryManager sharedManager].autoPageViewTrackingDisabled = YES;
+#pragma clang diagnostic pop
+    }
+    if ([self isAutoLifeCycleTrackingDisabled]) {
+      MSAILog(@"INFO: Auto life cycle tracking disabled");
+      [MSAITelemetryManager sharedManager].autoLifeCycleTrackingDisabled = YES;
+      
+      MSAILog(@"INFO: Auto page views disabled");
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      [MSAITelemetryManager sharedManager].autoPageViewTrackingDisabled = YES;
+#pragma clang diagnostic pop
     }
     
     
@@ -207,6 +219,20 @@ NSString *const kMSAIInstrumentationKey = @"MSAIInstrumentationKey";
 
 + (void)setTelemetryManagerDisabled:(BOOL)telemetryManagerDisabled {
   [[self sharedInstance] setTelemetryManagerDisabled:telemetryManagerDisabled];
+}
+
+- (void)setAutoLifeCycleTrackingDisabled:(BOOL)autoLifeCycleTrackingDisabled {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  [self setAutoPageViewTrackingDisabled:autoLifeCycleTrackingDisabled];
+#pragma clang diagnostic pop
+  
+  [MSAITelemetryManager sharedManager].autoLifeCycleTrackingDisabled = autoLifeCycleTrackingDisabled;
+  _autoLifeCycleTrackingDisabled = autoLifeCycleTrackingDisabled;
+}
+
++ (void)setAutoLifeCycleTrackingDisabled:(BOOL)autoLifeCycleTrackingDisabled {
+  
 }
 
 - (void)setAutoPageViewTrackingDisabled:(BOOL)autoPageViewTrackingDisabled {

--- a/Classes/MSAICategoryContainer.m
+++ b/Classes/MSAICategoryContainer.m
@@ -25,7 +25,10 @@
 - (void)msai_viewWillAppear:(BOOL)animated {
   [self msai_viewWillAppear:animated];
 #if MSAI_FEATURE_TELEMETRY  
-  if(![MSAITelemetryManager sharedManager].autoPageViewTrackingDisabled){
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  if(![MSAITelemetryManager sharedManager].autoLifeCycleTrackingDisabled && ![MSAITelemetryManager sharedManager].autoPageViewTrackingDisabled){
+#pragma clang diagnostic pop
     NSString *pageViewName = [NSString stringWithFormat:@"%@ %@", NSStringFromClass([self class]), self.title];
     [MSAITelemetryManager trackPageView:pageViewName];
   }

--- a/Classes/MSAITelemetryManager.m
+++ b/Classes/MSAITelemetryManager.m
@@ -102,11 +102,11 @@ static char *const MSAITelemetryEventQueue = "com.microsoft.ApplicationInsights.
   
   if (!_appWillResignActiveObserver) {
     _appWillResignActiveObserver = [center addObserverForName:UIApplicationWillResignActiveNotification
-                                                         object:nil
-                                                          queue:NSOperationQueue.mainQueue
-                                                     usingBlock:^(NSNotification *notification) {
-                                                       [[MSAIChannel sharedChannel] persistDataItemQueue];
-                                                     }];
+                                                       object:nil
+                                                        queue:NSOperationQueue.mainQueue
+                                                   usingBlock:^(NSNotification *notification) {
+                                                     [[MSAIChannel sharedChannel] persistDataItemQueue];
+                                                   }];
   }
   
   if(!_sessionStartedObserver){
@@ -134,7 +134,7 @@ static char *const MSAITelemetryEventQueue = "com.microsoft.ApplicationInsights.
                                                       queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification *note) {
                                                         typeof(self) strongSelf = weakSelf;
                                                         [strongSelf trackOrientationChange];
-                                                    }];
+                                                      }];
   }
 }
 
@@ -305,51 +305,59 @@ static char *const MSAITelemetryEventQueue = "com.microsoft.ApplicationInsights.
 #pragma mark - App Start
 
 - (void)trackAppStart {
-  [self trackEventWithName:@"App started"];
+  if (!self.autoLifeCycleTrackingDisabled) {
+    [self trackEventWithName:@"App started"];
+  }
 }
 
 #pragma mark - Foreground / Background
 
 - (void)trackEnterForeground {
-  [self trackEventWithName:@"App will enter foreground"];
+  if (!self.autoLifeCycleTrackingDisabled) {
+    [self trackEventWithName:@"App will enter foreground"];
+  }
 }
 
 - (void)trackEnterBackground {
-  [self trackEventWithName:@"App did enter background"];
+  if (!self.autoLifeCycleTrackingDisabled) {
+    [self trackEventWithName:@"App did enter background"];
+  }
 }
 
 #pragma mark - Orientation Change
 
 - (void)trackOrientationChange {
-  UIInterfaceOrientation *currentOrientation = [UIDevice currentDevice].orientation;
-  NSDictionary *properties;
-  switch ((int)currentOrientation) {
-    case UIDeviceOrientationUnknown:
-      properties = @{@"orientation":@"UIDeviceOrientationUnknown"};
-      break;
-    case UIDeviceOrientationPortrait:
-      properties = @{@"orientation":@"UIDeviceOrientationPortrait"};
-      break;
-    case UIDeviceOrientationPortraitUpsideDown:
-      properties = @{@"orientation":@"UIDeviceOrientationPortraitUpsideDown"};
-      break;
-    case UIDeviceOrientationLandscapeLeft:
-      properties = @{@"orientation":@"UIDeviceOrientationLandscapeLeft"};
-      break;
-    case UIDeviceOrientationLandscapeRight:
-      properties = @{@"orientation":@"UIDeviceOrientationLandscapeRight"};
-      break;
-    case UIDeviceOrientationFaceUp:
-      properties = @{@"orientation":@"UIDeviceOrientationFaceUp"};
-      break;
-    case UIDeviceOrientationFaceDown:
-      properties = @{@"orientation":@"UIDeviceOrientationFaceDown"};
-      break;
-    default:
-      properties = @{@"orientation":@"UIDeviceOrientationUnknown"};
-      break;
+  if (!self.autoLifeCycleTrackingDisabled) {
+    UIInterfaceOrientation *currentOrientation = [UIDevice currentDevice].orientation;
+    NSDictionary *properties;
+    switch ((int)currentOrientation) {
+      case UIDeviceOrientationUnknown:
+        properties = @{@"orientation":@"UIDeviceOrientationUnknown"};
+        break;
+      case UIDeviceOrientationPortrait:
+        properties = @{@"orientation":@"UIDeviceOrientationPortrait"};
+        break;
+      case UIDeviceOrientationPortraitUpsideDown:
+        properties = @{@"orientation":@"UIDeviceOrientationPortraitUpsideDown"};
+        break;
+      case UIDeviceOrientationLandscapeLeft:
+        properties = @{@"orientation":@"UIDeviceOrientationLandscapeLeft"};
+        break;
+      case UIDeviceOrientationLandscapeRight:
+        properties = @{@"orientation":@"UIDeviceOrientationLandscapeRight"};
+        break;
+      case UIDeviceOrientationFaceUp:
+        properties = @{@"orientation":@"UIDeviceOrientationFaceUp"};
+        break;
+      case UIDeviceOrientationFaceDown:
+        properties = @{@"orientation":@"UIDeviceOrientationFaceDown"};
+        break;
+      default:
+        properties = @{@"orientation":@"UIDeviceOrientationUnknown"};
+        break;
+    }
+    [self trackEventWithName:@"Device orientation changed" properties:properties];
   }
-  [self trackEventWithName:@"Device orientation changed" properties:properties];
 }
 
 #pragma mark - Session update

--- a/Classes/MSAITelemetryManager.m
+++ b/Classes/MSAITelemetryManager.m
@@ -133,7 +133,7 @@ static char *const MSAITelemetryEventQueue = "com.microsoft.ApplicationInsights.
                                                      object:nil
                                                       queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification *note) {
                                                         typeof(self) strongSelf = weakSelf;
-                                                        [strongSelf trackOrientationChange];
+          [strongSelf trackCurrentOrientation];
                                                       }];
   }
 }
@@ -326,7 +326,7 @@ static char *const MSAITelemetryEventQueue = "com.microsoft.ApplicationInsights.
 
 #pragma mark - Orientation Change
 
-- (void)trackOrientationChange {
+- (void)trackCurrentOrientation {
   if (!self.autoLifeCycleTrackingDisabled) {
     UIInterfaceOrientation *currentOrientation = [UIDevice currentDevice].orientation;
     NSDictionary *properties;

--- a/Classes/MSAITelemetryManagerPrivate.h
+++ b/Classes/MSAITelemetryManagerPrivate.h
@@ -36,6 +36,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property BOOL autoPageViewTrackingDisabled __deprecated_msg("Use autoLifeCycleTrackingDisabled instead!");
 
+/**
+ *  A flag which determines whether page views, background/foreground switches and app cold starts are automatically detected and tracked.
+ *  Defaults to NO.
+ */
 @property BOOL autoLifeCycleTrackingDisabled;
 
 /**
@@ -50,7 +54,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)trackDataItem:(MSAITelemetryData *)dataItem;
 
-- (void)trackOrientationChange;
+/**
+ *  Track an event with the current device orientation
+ */
+- (void)trackCurrentOrientation;
 
 /**
  * Registers the manager for all notifications that are necessary for automatic session tracking

--- a/Classes/MSAITelemetryManagerPrivate.h
+++ b/Classes/MSAITelemetryManagerPrivate.h
@@ -48,6 +48,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)trackDataItem:(MSAITelemetryData *)dataItem;
 
+- (void)trackOrientationChange;
+
 /**
  * Registers the manager for all notifications that are necessary for automatic session tracking
  */

--- a/Classes/MSAITelemetryManagerPrivate.h
+++ b/Classes/MSAITelemetryManagerPrivate.h
@@ -34,7 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
  *  A flag which determines rather collecting page views automatically is enabled or not.
  *  NO by default.
  */
-@property BOOL autoPageViewTrackingDisabled;
+@property BOOL autoPageViewTrackingDisabled __deprecated_msg("Use autoLifeCycleTrackingDisabled instead!");
+
+@property BOOL autoLifeCycleTrackingDisabled;
 
 /**
  *  A concurrent queue which creates telemetry objects and forwards them to the channel.

--- a/Support/ApplicationInsightsTests/MSAITelemetryManagerTests.m
+++ b/Support/ApplicationInsightsTests/MSAITelemetryManagerTests.m
@@ -83,8 +83,8 @@
 
 - (void)testTrackOrientationChange {
   self.sut = OCMPartialMock([MSAITelemetryManager new]);
-  
-  [self.sut trackOrientationChange];
+
+  [self.sut trackCurrentOrientation];
   
   OCMVerify([self.sut trackEventWithName:[OCMArg isEqual:@"Device orientation changed"] properties:[OCMArg any]]);
 }

--- a/Support/ApplicationInsightsTests/MSAITelemetryManagerTests.m
+++ b/Support/ApplicationInsightsTests/MSAITelemetryManagerTests.m
@@ -72,8 +72,19 @@
   [self.sut unregisterObservers];
   
   [self.sut registerObservers];
+  OCMVerify([self.mockNotificationCenter addObserverForName:UIApplicationDidEnterBackgroundNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:[OCMArg any]]);
+  OCMVerify([self.mockNotificationCenter addObserverForName:UIApplicationWillResignActiveNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:[OCMArg any]]);
   OCMVerify([self.mockNotificationCenter addObserverForName:MSAISessionStartedNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:[OCMArg any]]);
   OCMVerify([self.mockNotificationCenter addObserverForName:MSAISessionEndedNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:[OCMArg any]]);
+  OCMVerify([self.mockNotificationCenter addObserverForName:UIDeviceOrientationDidChangeNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:[OCMArg any]]);
+}
+
+- (void)testTrackOrientationChange {
+  self.sut = OCMPartialMock([MSAITelemetryManager new]);
+  
+  [self.sut trackOrientationChange];
+  
+  OCMVerify([self.sut trackEventWithName:[OCMArg isEqual:@"Device orientation changed"] properties:[OCMArg any]]);
 }
 
 @end

--- a/Support/ApplicationInsightsTests/MSAITelemetryManagerTests.m
+++ b/Support/ApplicationInsightsTests/MSAITelemetryManagerTests.m
@@ -72,6 +72,8 @@
   [self.sut unregisterObservers];
   
   [self.sut registerObservers];
+  OCMVerify([self.mockNotificationCenter addObserverForName:UIApplicationDidFinishLaunchingNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:[OCMArg any]]);
+  OCMVerify([self.mockNotificationCenter addObserverForName:UIApplicationWillEnterForegroundNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:[OCMArg any]]);
   OCMVerify([self.mockNotificationCenter addObserverForName:UIApplicationDidEnterBackgroundNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:[OCMArg any]]);
   OCMVerify([self.mockNotificationCenter addObserverForName:UIApplicationWillResignActiveNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:[OCMArg any]]);
   OCMVerify([self.mockNotificationCenter addObserverForName:MSAISessionStartedNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:[OCMArg any]]);


### PR DESCRIPTION
This adds automatic tracking of interesting app lifecycle events like backgrounding, foregrounding and cold app starts.

- [x] Add observers to `disableAutoLifecycleTracking` switch
- [ ] Add tests for foreground, background, app start?
