### PR TITLE
Fix syntax of Swift examples so they compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,27 +130,27 @@ You can also use the following shortcuts:
 2. Add the following line at the top of the file below your own #import statements:
 	
 ```swift
-#import ApplicationInsights
+import ApplicationInsights
 ```
 
 3. Search for the method 
 	
 ```swift
-application(application: UIApplication, didFinishLaunchingWithOptions launchOptions:[NSObject: AnyObject]?) -> Bool`
+application(application: UIApplication, didFinishLaunchingWithOptions launchOptions:[NSObject: AnyObject]?) -> Bool
 ```
 
 4. Add the following lines to setup and start the Application Insights SDK:
 	
 ```swift
-MSAIApplicationInsights.sharedInstance().setup();
-MSAIApplicationInsights.sharedInstance().start();
+MSAIApplicationInsights.sharedInstance().setup()
+MSAIApplicationInsights.sharedInstance().start()
 ```
 	
 You can also use the following shortcuts:
 
 ```swift
-MSAIApplicationInsights.setup();
-MSAIApplicationInsights.start();
+MSAIApplicationInsights.setup()
+MSAIApplicationInsights.start()
 ```
 	
 **Congratulation, now you're all set to use Application Insights! See [Basic Usage](#basicusage) on how to use Application Insights.**
@@ -266,23 +266,23 @@ After you have setup the SDK as [described above](#setup), the ```MSAITelemetryM
 
 ```swift
 // Send an event with custom properties and measuremnts data
-MSAITelemetryManager.trackEventWithName(name:"Hello World event!", 
-								  properties:@{"Test property 1":"Some value",
-											  "Test property 2":"Some other value"},
-							    measurements:@{"Test measurement 1":@(4.8),
-											  "Test measurement 2":@(15.16),
-										      "Test measurement 3":@(23.42)});
+MSAITelemetryManager.trackEventWithName("Hello World event!", 
+								  properties:["Test property 1":"Some value",
+											  "Test property 2":"Some other value"],
+							    measurements:["Test measurement 1":4.8,
+											  "Test measurement 2":15.16,
+										      "Test measurement 3":23.42])
 
 // Send a message
-MSAITelemetryManager.trackTraceWithMessage(message:"Test message");
+MSAITelemetryManager.trackTraceWithMessage("Test message");
 
 // Manually send pageviews
-MSAITelemetryManager.trackPageView(pageView:"MyViewController",
+MSAITelemetryManager.trackPageView("MyViewController",
 								   duration:300,
-							     properties:@{"Test measurement 1":@(4.8)});
+							     properties:["Test measurement 1":4.8]);
 
 // Send a message
-MSAITelemetryManager.trackMetricWithName(name:"Test metric", value:42.2);
+MSAITelemetryManager.trackMetricWithName("Test metric", value:42.2);
 ```
 
 <a name="autolifecycle"></a>


### PR DESCRIPTION
The Swift examples in the README.md had various syntax issues.