### PR TITLE
Add ExceptionName to crash reports

### DIFF
--- a/Classes/MSAICrashDataProvider.m
+++ b/Classes/MSAICrashDataProvider.m
@@ -414,7 +414,7 @@ static const char *findSEL (const char *imageName, NSString *imageUUID, uint64_t
   
   /* Uncaught Exception */
   if (report.hasExceptionInfo) {
-    crashHeaders.exceptionReason = report.exceptionInfo.exceptionReason;
+    crashHeaders.exceptionReason = [NSString stringWithFormat:@"%@: %@", report.exceptionInfo.exceptionName, report.exceptionInfo.exceptionReason];
   } else if (crashed_thread != nil) {
     // try to find the selector in case this was a crash in obj_msgSend
     // we search this wether the crash happend in obj_msgSend or not since we don't have the symbol!


### PR DESCRIPTION
If the crash is triggered by an exception, we should also send the exception name and not only the exception reason.