### PR TITLE
Add C++ Exception support

### DIFF
--- a/ApplicationInsights.podspec
+++ b/ApplicationInsights.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc    = true
 
   s.frameworks      = 'UIKit', 'Foundation', 'SystemConfiguration', 'Security'
-  s.libraries       = 'z'
+  s.libraries       = 'z', 'c++'
   s.weak_framework  = 'CoreTelephony'
 
   s.ios.vendored_frameworks = 'ApplicationInsights/ApplicationInsights.framework'

--- a/Classes/ApplicationInsights.h
+++ b/Classes/ApplicationInsights.h
@@ -1,5 +1,3 @@
-#ifndef MSAI_h
-#define MSAI_h
 
 #import "ApplicationInsightsFeatureConfig.h"
 #import "MSAINullability.h"
@@ -58,5 +56,3 @@ extern NSString *const __unused kMSAIErrorDomain;
 NS_ASSUME_NONNULL_END
 
 #endif /* MSAI_FEATURE_CRASH_REPORTER */
-
-#endif /* MSAI_h */

--- a/Classes/MSAICrashCXXExceptionHandler.h
+++ b/Classes/MSAICrashCXXExceptionHandler.h
@@ -1,0 +1,49 @@
+/*
+ * Author: Gwynne Raskind <gwraskin@microsoft.com>
+ *
+ * Copyright (c) 2015 HockeyApp, Bit Stadium GmbH.
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import "MSAINullability.h"
+
+typedef struct {
+    const void * __nullable exception;
+    const char * __nullable exception_type_name;
+    const char * __nullable exception_message;
+    uint32_t exception_frames_count;
+    const uintptr_t * __nonnull exception_frames;
+} MSAICrashUncaughtCXXExceptionInfo;
+
+typedef void (*MSAICrashUncaughtCXXExceptionHandler)(
+    const MSAICrashUncaughtCXXExceptionInfo * __nonnull info
+);
+
+@interface MSAICrashUncaughtCXXExceptionHandlerManager : NSObject
+
++ (void)addCXXExceptionHandler:(nonnull MSAICrashUncaughtCXXExceptionHandler)handler;
++ (void)removeCXXExceptionHandler:(nonnull MSAICrashUncaughtCXXExceptionHandler)handler;
+
+@end

--- a/Classes/MSAICrashCXXExceptionHandler.h
+++ b/Classes/MSAICrashCXXExceptionHandler.h
@@ -1,31 +1,3 @@
-/*
- * Author: Gwynne Raskind <gwraskin@microsoft.com>
- *
- * Copyright (c) 2015 HockeyApp, Bit Stadium GmbH.
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- */
-
 #import <Foundation/Foundation.h>
 #import "MSAINullability.h"
 

--- a/Classes/MSAICrashCXXExceptionHandler.mm
+++ b/Classes/MSAICrashCXXExceptionHandler.mm
@@ -1,0 +1,150 @@
+/*
+ * Author: Gwynne Raskind <gwraskin@microsoft.com>
+ *
+ * Copyright (c) 2015 HockeyApp, Bit Stadium GmbH.
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "MSAICrashCXXExceptionHandler.h"
+#import <vector>
+#import <cxxabi.h>
+#import <exception>
+#import <stdexcept>
+#import <typeinfo>
+#import <string>
+#import <pthread.h>
+#import <dlfcn.h>
+#import <execinfo.h>
+#import <libkern/OSAtomic.h>
+
+typedef std::vector<MSAICrashUncaughtCXXExceptionHandler> MSAICrashUncaughtCXXExceptionHandlerList;
+
+static bool _MSAICrashIsOurTerminateHandlerInstalled = false;
+static std::terminate_handler _MSAICrashOriginalTerminateHandler = nullptr;
+static MSAICrashUncaughtCXXExceptionHandlerList _MSAICrashUncaughtExceptionHandlerList;
+static OSSpinLock _MSAICrashCXXExceptionHandlingLock = OS_SPINLOCK_INIT;
+
+@implementation MSAICrashUncaughtCXXExceptionHandlerManager
+
+__attribute__((always_inline))
+static inline void MSAICrashIterateExceptionHandlers_unlocked(const MSAICrashUncaughtCXXExceptionInfo &info)
+{
+    for (const auto &handler : _MSAICrashUncaughtExceptionHandlerList) {
+        handler(&info);
+    }
+}
+
+static void MSAICrashUncaughtCXXTerminateHandler(void)
+{
+    MSAICrashUncaughtCXXExceptionInfo info = {
+        .exception = nullptr,
+        .exception_type_name = nullptr,
+        .exception_message = nullptr,
+        .exception_frames_count = 0,
+        .exception_frames = nullptr,
+    };
+    auto p = std::current_exception();
+    
+    OSSpinLockLock(&_MSAICrashCXXExceptionHandlingLock); {
+      if (p) { // explicit operator bool
+          info.exception = reinterpret_cast<const void *>(&p);
+          info.exception_type_name = __cxxabiv1::__cxa_current_exception_type()->name();
+        
+          void *frames[128] = { nullptr };
+        
+          info.exception_frames_count = backtrace(&frames[0], sizeof(frames) / sizeof(frames[0])) - 1;
+          info.exception_frames = reinterpret_cast<uintptr_t *>(&frames[1]);
+        
+          try {
+              std::rethrow_exception(p);
+          } catch (const std::exception &e) { // C++ exception.
+              info.exception_message = e.what();
+              MSAICrashIterateExceptionHandlers_unlocked(info);
+          } catch (const std::exception *e) { // C++ exception by pointer.
+              info.exception_message = e->what();
+              MSAICrashIterateExceptionHandlers_unlocked(info);
+          } catch (const std::string &e) { // C++ string as exception.
+              info.exception_message = e.c_str();
+              MSAICrashIterateExceptionHandlers_unlocked(info);
+          } catch (const std::string *e) { // C++ string pointer as exception.
+              info.exception_message = e->c_str();
+              MSAICrashIterateExceptionHandlers_unlocked(info);
+          } catch (const char *e) { // Plain string as exception.
+              info.exception_message = e;
+              MSAICrashIterateExceptionHandlers_unlocked(info);
+          } catch (id e) { // Objective-C exception. Pass it on to Foundation.
+              OSSpinLockUnlock(&_MSAICrashCXXExceptionHandlingLock);
+              if (_MSAICrashOriginalTerminateHandler != nullptr) {
+                  _MSAICrashOriginalTerminateHandler();
+              }
+              return;
+          } catch (...) { // Any other kind of exception. No message.
+              MSAICrashIterateExceptionHandlers_unlocked(info);
+          }
+      }
+    } OSSpinLockUnlock(&_MSAICrashCXXExceptionHandlingLock); // In case terminate is called reentrantly by pasing it on
+  
+    if (_MSAICrashOriginalTerminateHandler != nullptr) {
+        _MSAICrashOriginalTerminateHandler();
+    } else {
+        abort();
+    }
+}
+
++ (void)addCXXExceptionHandler:(MSAICrashUncaughtCXXExceptionHandler)handler
+{
+    OSSpinLockLock(&_MSAICrashCXXExceptionHandlingLock); {
+        if (!_MSAICrashIsOurTerminateHandlerInstalled) {
+            _MSAICrashOriginalTerminateHandler = std::set_terminate(MSAICrashUncaughtCXXTerminateHandler);
+            _MSAICrashIsOurTerminateHandlerInstalled = true;
+        }
+        _MSAICrashUncaughtExceptionHandlerList.push_back(handler);
+    } OSSpinLockUnlock(&_MSAICrashCXXExceptionHandlingLock);
+}
+
++ (void)removeCXXExceptionHandler:(MSAICrashUncaughtCXXExceptionHandler)handler
+{
+    OSSpinLockLock(&_MSAICrashCXXExceptionHandlingLock); {
+        auto i = std::find(_MSAICrashUncaughtExceptionHandlerList.begin(), _MSAICrashUncaughtExceptionHandlerList.end(), handler);
+      
+        if (i != _MSAICrashUncaughtExceptionHandlerList.end()) {
+          _MSAICrashUncaughtExceptionHandlerList.erase(i);
+        }
+    
+        if (_MSAICrashIsOurTerminateHandlerInstalled) {
+            if (_MSAICrashUncaughtExceptionHandlerList.empty()) {
+                std::terminate_handler previous_handler = std::set_terminate(_MSAICrashOriginalTerminateHandler);
+                
+                if (previous_handler != MSAICrashUncaughtCXXTerminateHandler) {
+                    std::set_terminate(previous_handler);
+                } else {
+                    _MSAICrashIsOurTerminateHandlerInstalled = false;
+                    _MSAICrashOriginalTerminateHandler = nullptr;
+                }
+            }
+        }
+    } OSSpinLockUnlock(&_MSAICrashCXXExceptionHandlingLock);
+}
+
+@end

--- a/Classes/MSAICrashCXXExceptionHandler.mm
+++ b/Classes/MSAICrashCXXExceptionHandler.mm
@@ -1,31 +1,3 @@
-/*
- * Author: Gwynne Raskind <gwraskin@microsoft.com>
- *
- * Copyright (c) 2015 HockeyApp, Bit Stadium GmbH.
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- */
-
 #import "MSAICrashCXXExceptionHandler.h"
 #import <vector>
 #import <cxxabi.h>

--- a/Classes/MSAICrashManager.m
+++ b/Classes/MSAICrashManager.m
@@ -8,6 +8,7 @@
 #import "MSAICrashDataProvider.h"
 #import "MSAICrashDetailsPrivate.h"
 #import "MSAICrashData.h"
+#import "MSAICrashCXXExceptionHandler.h"
 #import "MSAIChannel.h"
 #import "MSAIChannelPrivate.h"
 #import "MSAIPersistencePrivate.h"
@@ -61,6 +62,64 @@ static PLCrashReporterCallbacks defaultCallback = {
   .context = NULL,
   .handleSignal = msai_save_events_callback
 };
+
+
+// Temporary class until PLCR catches up
+// We trick PLCR with an Objective-C exception.
+//
+// This code provides us access to the C++ exception message, but we won't get a correct stack trace.
+// The cause for this is that the iOS runtime catches every C++ exception internally and rethrows it.
+// Since the exception object doesn't have the backtrace attached, we have no chance of accessing it.
+//
+// As a workaround we could hook into __cxx_throw and attaching the backtrace every time this is called.
+// This has a few sides effects which is why we are not doing this right now:
+// - CoreAdudio (and possibly other frameworks) use C++ exceptions heavily for control flow.
+//   Calling `backtrace()` is not cheap, so this could affect performance
+// - It is not clear if such a hook is ABI compatible with all C++ runtimes
+// - It is not clear if there could be any other side effects
+//
+// We'll evaluate this further to see if there is a safe solution.
+//
+@interface BITCrashCXXExceptionWrapperException : NSException
+- (instancetype)initWithCXXExceptionInfo:(const MSAICrashUncaughtCXXExceptionInfo *)info;
+@end
+
+@implementation BITCrashCXXExceptionWrapperException {
+  const MSAICrashUncaughtCXXExceptionInfo *_info;
+}
+
+- (instancetype)initWithCXXExceptionInfo:(const MSAICrashUncaughtCXXExceptionInfo *)info {
+  extern char* __cxa_demangle(const char* mangled_name, char* output_buffer, size_t* length, int* status);
+  char *demangled_name = __cxa_demangle ? __cxa_demangle(info->exception_type_name ?: "", NULL, NULL, NULL) : NULL;
+  
+  if ((self = [super
+               initWithName:[NSString stringWithUTF8String:demangled_name ?: info->exception_type_name ?: ""]
+               reason:[NSString stringWithUTF8String:info->exception_message ?: ""]
+               userInfo:nil])) {
+    _info = info;
+  }
+  return self;
+}
+
+- (NSArray *)callStackReturnAddresses {
+  NSMutableArray *cxxFrames = [NSMutableArray arrayWithCapacity:_info->exception_frames_count];
+  
+  for (uint32_t i = 0; i < _info->exception_frames_count; ++i) {
+    [cxxFrames addObject:[NSNumber numberWithUnsignedLongLong:_info->exception_frames[i]]];
+  }
+  return cxxFrames;
+}
+
+@end
+
+
+// C++ Exception Handler
+static void uncaught_cxx_exception_handler(const MSAICrashUncaughtCXXExceptionInfo *info) {
+  // This relies on a LOT of sneaky internal knowledge of how PLCR works and should not be considered a long-term solution.
+  NSGetUncaughtExceptionHandler()([[BITCrashCXXExceptionWrapperException alloc] initWithCXXExceptionInfo:info]);
+  abort();
+}
+
 
 @implementation MSAICrashManager {
   id _appDidBecomeActiveObserver;
@@ -215,6 +274,9 @@ static PLCrashReporterCallbacks defaultCallback = {
       // this should never happen, theoretically only if NSSetUncaugtExceptionHandler() has some internal issues
       NSLog(@"[ApplicationInsights] ERROR: Exception handler could not be set. Make sure there is no other exception handler set up!");
     }
+    
+    // Add the C++ uncaught exception handler, which is currently not handled by PLCrashReporter internally
+    [MSAICrashUncaughtCXXExceptionHandlerManager addCXXExceptionHandler:uncaught_cxx_exception_handler];
   }
 }
 

--- a/Support/ApplicationInsights.xcconfig
+++ b/Support/ApplicationInsights.xcconfig
@@ -1,3 +1,3 @@
-OTHER_LDFLAGS=$(inherited) -framework CFNetwork -framework Foundation -framework Security -framework SystemConfiguration -framework UIKit -weak_framework CoreTelephony -lz
+OTHER_LDFLAGS=$(inherited) -framework CFNetwork -framework Foundation -framework Security -framework SystemConfiguration -framework UIKit -weak_framework CoreTelephony -lz -lc++
 MSAI_DOCSET_NAME=ApplicationInsights
 GCC_PREPROCESSOR_DEFINITIONS=$(inherited) CONFIGURATION_$(CONFIGURATION)

--- a/Support/ApplicationInsights.xcodeproj/project.pbxproj
+++ b/Support/ApplicationInsights.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		1BE53D771AB889420048ABBC /* MSAIContextHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BE53D751AB889420048ABBC /* MSAIContextHelper.m */; };
 		1E0FEE28173BDB260061331F /* MSAIKeychainUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E0FEE26173BDB260061331F /* MSAIKeychainUtils.h */; };
 		1E0FEE29173BDB260061331F /* MSAIKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E0FEE27173BDB260061331F /* MSAIKeychainUtils.m */; };
+		1E3A26111B2B2C8B00D59683 /* MSAICrashCXXExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E3A260F1B2B2C8B00D59683 /* MSAICrashCXXExceptionHandler.h */; };
+		1E3A26121B2B2C8B00D59683 /* MSAICrashCXXExceptionHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1E3A26101B2B2C8B00D59683 /* MSAICrashCXXExceptionHandler.mm */; };
 		1E49A4BE161222B900463151 /* MSAIHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E49A4A5161222B900463151 /* MSAIHelper.h */; };
 		1E49A4C1161222B900463151 /* MSAIHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E49A4A6161222B900463151 /* MSAIHelper.m */; };
 		1E49A4D8161222D400463151 /* ApplicationInsightsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E49A4D4161222D400463151 /* ApplicationInsightsPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -266,6 +268,9 @@
 		1BE53D751AB889420048ABBC /* MSAIContextHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSAIContextHelper.m; sourceTree = "<group>"; };
 		1E0FEE26173BDB260061331F /* MSAIKeychainUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSAIKeychainUtils.h; sourceTree = "<group>"; };
 		1E0FEE27173BDB260061331F /* MSAIKeychainUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSAIKeychainUtils.m; sourceTree = "<group>"; };
+		1E3A260F1B2B2C8B00D59683 /* MSAICrashCXXExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSAICrashCXXExceptionHandler.h; sourceTree = "<group>"; };
+		1E3A26101B2B2C8B00D59683 /* MSAICrashCXXExceptionHandler.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MSAICrashCXXExceptionHandler.mm; sourceTree = "<group>"; };
+		1E3A26131B2B2CFE00D59683 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
 		1E3A2B4C19645DC800D5BD66 /* ApplicationInsights-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ApplicationInsights-Prefix.pch"; sourceTree = "<group>"; };
 		1E49A4A5161222B900463151 /* MSAIHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSAIHelper.h; sourceTree = "<group>"; };
 		1E49A4A6161222B900463151 /* MSAIHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSAIHelper.m; sourceTree = "<group>"; };
@@ -659,6 +664,8 @@
 				1E754E571621FBB70070AB92 /* MSAICrashManager.m */,
 				1E754E581621FBB70070AB92 /* MSAICrashManagerDelegate.h */,
 				1EFF03D717F20F8300A5F13C /* MSAICrashManagerPrivate.h */,
+				1E3A260F1B2B2C8B00D59683 /* MSAICrashCXXExceptionHandler.h */,
+				1E3A26101B2B2C8B00D59683 /* MSAICrashCXXExceptionHandler.mm */,
 				1E754E5A1621FBB70070AB92 /* MSAICrashDataProvider.h */,
 				1E754E5B1621FBB70070AB92 /* MSAICrashDataProvider.m */,
 			);
@@ -729,6 +736,7 @@
 		E400561C148D79B500EB22B9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1E3A26131B2B2CFE00D59683 /* libc++.dylib */,
 				80B69EEF1ADDC49100C47B0A /* libz.dylib */,
 				1B3B73071A94BC8E008DCADA /* CoreTelephony.framework */,
 				1B85606E1A7A6A9D00A54FB7 /* UIKit.framework */,
@@ -823,6 +831,7 @@
 				1E49A4D8161222D400463151 /* ApplicationInsightsPrivate.h in Headers */,
 				803871C01A94C26500BF295F /* MSAICrashManagerPrivate.h in Headers */,
 				803871C21A94C26500BF295F /* MSAIContextPrivate.h in Headers */,
+				1E3A26111B2B2C8B00D59683 /* MSAICrashCXXExceptionHandler.h in Headers */,
 				803871C31A94C26500BF295F /* MSAITelemetryManagerPrivate.h in Headers */,
 				1ECA8F4D192B5BD8006B9416 /* MSAICrashDetailsPrivate.h in Headers */,
 				80F334B21A9C93290098026F /* MSAIApplicationInsightsPrivate.h in Headers */,
@@ -1026,6 +1035,7 @@
 				1BBBCF371A6594AE00253031 /* MSAITelemetryContext.m in Sources */,
 				807CFDC21A712974004EA1B6 /* MSAIMetricData.m in Sources */,
 				1B47E02F1A84D3DF000B4C3D /* MSAIEnvelopeManager.m in Sources */,
+				1E3A26121B2B2C8B00D59683 /* MSAICrashCXXExceptionHandler.mm in Sources */,
 				807CFDB81A712974004EA1B6 /* MSAIExceptionData.m in Sources */,
 				E40E0B0D17DA1AFF005E38C1 /* MSAIAppClient.m in Sources */,
 				807CFDA61A712974004EA1B6 /* MSAIBase.m in Sources */,
@@ -1146,6 +1156,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"ARCHS[sdk=iphonesimulator*]" = "$(MSAI_SIM_ARCHS)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				DSTROOT = /tmp/AIS.dst;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1169,6 +1181,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"ARCHS[sdk=iphonesimulator*]" = "$(MSAI_SIM_ARCHS)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				DSTROOT = /tmp/AIS.dst;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1336,6 +1350,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"ARCHS[sdk=iphonesimulator*]" = "$(MSAI_SIM_ARCHS)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				DSTROOT = /tmp/AIS.dst;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Support/module.modulemap
+++ b/Support/module.modulemap
@@ -3,4 +3,6 @@ framework module ApplicationInsights {
   
   export *
   module * { export * }
+  
+  link "c++"
 }


### PR DESCRIPTION
This code provides us access to the C++ exception message, but we won't get a correct stack trace. The cause for this is that the iOS runtime catches every C++ exception internally and rethrows it. Since the exception object doesn't have the backtrace attached, we have no chance of accessing it.

As a workaround we could hook into `__cxx_throw` and attaching the backtrace every time this is called.
This has a few sides effects which is why we are not doing this right now:

- CoreAudio (and possibly other frameworks) use C++ exceptions heavily for control flow. Calling backtrace() is not cheap, so this could affect performance
- It is not clear if such a hook is ABI compatible with all C++ runtimes
- It is not clear if there could be any other side effects

We'll evaluate this further to see if there is a safe solution.