### PR TITLE
Improve C++ stack traces

### DIFF
--- a/Classes/MSAICrashCXXExceptionHandler.mm
+++ b/Classes/MSAICrashCXXExceptionHandler.mm
@@ -11,112 +11,195 @@
 #import <libkern/OSAtomic.h>
 
 typedef std::vector<MSAICrashUncaughtCXXExceptionHandler> MSAICrashUncaughtCXXExceptionHandlerList;
+typedef struct
+{
+  void *exception_object;
+  uintptr_t call_stack[128];
+  uint32_t num_frames;
+} MSAICrashCXXExceptionTSInfo;
 
 static bool _MSAICrashIsOurTerminateHandlerInstalled = false;
 static std::terminate_handler _MSAICrashOriginalTerminateHandler = nullptr;
 static MSAICrashUncaughtCXXExceptionHandlerList _MSAICrashUncaughtExceptionHandlerList;
 static OSSpinLock _MSAICrashCXXExceptionHandlingLock = OS_SPINLOCK_INIT;
+static pthread_key_t _MSAICrashCXXExceptionInfoTSDKey = 0;
 
 @implementation MSAICrashUncaughtCXXExceptionHandlerManager
+
+extern "C" void LIBCXXABI_NORETURN __cxa_throw(void *exception_object, std::type_info *tinfo, void (*dest)(void *))
+{
+  // Purposely do not take a lock in this function. The aim is to be as fast as
+  // possible. While we could really use some of the info set up by the real
+  // __cxa_throw, if we call through we never get control back - the function is
+  // noreturn and jumps to landing pads. Most of the stuff in __cxxabiv1 also
+  // won't work yet. We therefore have to do these checks by hand.
+  
+  // The technique for distinguishing Objective-C exceptions is based on the
+  // implementation of objc_exception_throw(). It's weird, but it's fast. The
+  // explicit symbol load and NULL checks should guard against the
+  // implementation changing in a future version. (Or not existing in an earlier
+  // version).
+  
+  typedef void (*cxa_throw_func)(void *, std::type_info *, void (*)(void *)) LIBCXXABI_NORETURN;
+  static dispatch_once_t predicate = 0;
+  static cxa_throw_func __original__cxa_throw = nullptr;
+  static const void **__real_objc_ehtype_vtable = nullptr;
+  
+  dispatch_once(&predicate, ^ {
+    __original__cxa_throw = reinterpret_cast<cxa_throw_func>(dlsym(RTLD_NEXT, "__cxa_throw"));
+    __real_objc_ehtype_vtable = reinterpret_cast<const void **>(dlsym(RTLD_DEFAULT, "objc_ehtype_vtable"));
+  });
+  
+  // Actually check for Objective-C exceptions.
+  if (tinfo && __real_objc_ehtype_vtable && // Guard from an ABI change
+      *reinterpret_cast<void **>(tinfo) == __real_objc_ehtype_vtable + 2) {
+    goto callthrough;
+  }
+  
+  // Any other exception that came here has to be C++, since Objective-C is the
+  // only (known) runtime that hijacks the C++ ABI this way. We need to save off
+  // a backtrace.
+  // Invariant: If the terminate handler is installed, the TSD key must also be
+  // initialized.
+  if (_MSAICrashIsOurTerminateHandlerInstalled) {
+    MSAICrashCXXExceptionTSInfo *info = static_cast<MSAICrashCXXExceptionTSInfo *>(pthread_getspecific(_MSAICrashCXXExceptionInfoTSDKey));
+    
+    if (!info) {
+      info = reinterpret_cast<MSAICrashCXXExceptionTSInfo *>(calloc(1, sizeof(MSAICrashCXXExceptionTSInfo)));
+      pthread_setspecific(_MSAICrashCXXExceptionInfoTSDKey, info);
+    }
+    info->exception_object = exception_object;
+    // XXX: All significant time in this call is spent right here.
+    info->num_frames = backtrace(reinterpret_cast<void **>(&info->call_stack[0]), sizeof(info->call_stack) / sizeof(info->call_stack[0]));
+  }
+  
+callthrough:
+  if (__original__cxa_throw) {
+    __original__cxa_throw(exception_object, tinfo, dest);
+  } else {
+    abort();
+  }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunreachable-code"
+  __builtin_unreachable();
+#pragma clang diagnostic pop
+}
 
 __attribute__((always_inline))
 static inline void MSAICrashIterateExceptionHandlers_unlocked(const MSAICrashUncaughtCXXExceptionInfo &info)
 {
-    for (const auto &handler : _MSAICrashUncaughtExceptionHandlerList) {
-        handler(&info);
-    }
+  for (const auto &handler : _MSAICrashUncaughtExceptionHandlerList) {
+    handler(&info);
+  }
 }
 
 static void MSAICrashUncaughtCXXTerminateHandler(void)
 {
-    MSAICrashUncaughtCXXExceptionInfo info = {
-        .exception = nullptr,
-        .exception_type_name = nullptr,
-        .exception_message = nullptr,
-        .exception_frames_count = 0,
-        .exception_frames = nullptr,
-    };
-    auto p = std::current_exception();
-    
-    OSSpinLockLock(&_MSAICrashCXXExceptionHandlingLock); {
-      if (p) { // explicit operator bool
-          info.exception = reinterpret_cast<const void *>(&p);
-          info.exception_type_name = __cxxabiv1::__cxa_current_exception_type()->name();
-        
-          void *frames[128] = { nullptr };
-        
-          info.exception_frames_count = backtrace(&frames[0], sizeof(frames) / sizeof(frames[0])) - 1;
-          info.exception_frames = reinterpret_cast<uintptr_t *>(&frames[1]);
-        
-          try {
-              std::rethrow_exception(p);
-          } catch (const std::exception &e) { // C++ exception.
-              info.exception_message = e.what();
-              MSAICrashIterateExceptionHandlers_unlocked(info);
-          } catch (const std::exception *e) { // C++ exception by pointer.
-              info.exception_message = e->what();
-              MSAICrashIterateExceptionHandlers_unlocked(info);
-          } catch (const std::string &e) { // C++ string as exception.
-              info.exception_message = e.c_str();
-              MSAICrashIterateExceptionHandlers_unlocked(info);
-          } catch (const std::string *e) { // C++ string pointer as exception.
-              info.exception_message = e->c_str();
-              MSAICrashIterateExceptionHandlers_unlocked(info);
-          } catch (const char *e) { // Plain string as exception.
-              info.exception_message = e;
-              MSAICrashIterateExceptionHandlers_unlocked(info);
-          } catch (id e) { // Objective-C exception. Pass it on to Foundation.
-              OSSpinLockUnlock(&_MSAICrashCXXExceptionHandlingLock);
-              if (_MSAICrashOriginalTerminateHandler != nullptr) {
-                  _MSAICrashOriginalTerminateHandler();
-              }
-              return;
-          } catch (...) { // Any other kind of exception. No message.
-              MSAICrashIterateExceptionHandlers_unlocked(info);
-          }
-      }
-    } OSSpinLockUnlock(&_MSAICrashCXXExceptionHandlingLock); // In case terminate is called reentrantly by pasing it on
+  MSAICrashUncaughtCXXExceptionInfo info = {
+    .exception = nullptr,
+    .exception_type_name = nullptr,
+    .exception_message = nullptr,
+    .exception_frames_count = 0,
+    .exception_frames = nullptr,
+  };
+  auto p = std::current_exception();
   
-    if (_MSAICrashOriginalTerminateHandler != nullptr) {
-        _MSAICrashOriginalTerminateHandler();
-    } else {
-        abort();
+  OSSpinLockLock(&_MSAICrashCXXExceptionHandlingLock); {
+    if (p) { // explicit operator bool
+      info.exception = reinterpret_cast<const void *>(&p);
+      info.exception_type_name = __cxxabiv1::__cxa_current_exception_type()->name();
+      
+      MSAICrashCXXExceptionTSInfo *recorded_info = reinterpret_cast<MSAICrashCXXExceptionTSInfo *>(pthread_getspecific(_MSAICrashCXXExceptionInfoTSDKey));
+      
+      if (recorded_info) {
+        info.exception_frames_count = recorded_info->num_frames - 1;
+        info.exception_frames = &recorded_info->call_stack[1];
+      } else {
+        // There's no backtrace, grab this function's trace instead. Probably
+        // means the exception came from a dynamically loaded library.
+        void *frames[128] = { nullptr };
+        
+        info.exception_frames_count = backtrace(&frames[0], sizeof(frames) / sizeof(frames[0])) - 1;
+        info.exception_frames = reinterpret_cast<uintptr_t *>(&frames[1]);
+      }
+      
+      try {
+        std::rethrow_exception(p);
+      } catch (const std::exception &e) { // C++ exception.
+        info.exception_message = e.what();
+        MSAICrashIterateExceptionHandlers_unlocked(info);
+      } catch (const std::exception *e) { // C++ exception by pointer.
+        info.exception_message = e->what();
+        MSAICrashIterateExceptionHandlers_unlocked(info);
+      } catch (const std::string &e) { // C++ string as exception.
+        info.exception_message = e.c_str();
+        MSAICrashIterateExceptionHandlers_unlocked(info);
+      } catch (const std::string *e) { // C++ string pointer as exception.
+        info.exception_message = e->c_str();
+        MSAICrashIterateExceptionHandlers_unlocked(info);
+      } catch (const char *e) { // Plain string as exception.
+        info.exception_message = e;
+        MSAICrashIterateExceptionHandlers_unlocked(info);
+      } catch (id e) { // Objective-C exception. Pass it on to Foundation.
+        OSSpinLockUnlock(&_MSAICrashCXXExceptionHandlingLock);
+        if (_MSAICrashOriginalTerminateHandler != nullptr) {
+          _MSAICrashOriginalTerminateHandler();
+        }
+        return;
+      } catch (...) { // Any other kind of exception. No message.
+        MSAICrashIterateExceptionHandlers_unlocked(info);
+      }
     }
+  } OSSpinLockUnlock(&_MSAICrashCXXExceptionHandlingLock); // In case terminate is called reentrantly by pasing it on
+  
+  if (_MSAICrashOriginalTerminateHandler != nullptr) {
+    _MSAICrashOriginalTerminateHandler();
+  } else {
+    abort();
+  }
 }
 
 + (void)addCXXExceptionHandler:(MSAICrashUncaughtCXXExceptionHandler)handler
 {
-    OSSpinLockLock(&_MSAICrashCXXExceptionHandlingLock); {
-        if (!_MSAICrashIsOurTerminateHandlerInstalled) {
-            _MSAICrashOriginalTerminateHandler = std::set_terminate(MSAICrashUncaughtCXXTerminateHandler);
-            _MSAICrashIsOurTerminateHandlerInstalled = true;
-        }
-        _MSAICrashUncaughtExceptionHandlerList.push_back(handler);
-    } OSSpinLockUnlock(&_MSAICrashCXXExceptionHandlingLock);
+  static dispatch_once_t key_predicate = 0;
+  
+  // This only EVER has to be done once, since we don't delete the TSD later
+  // (there's no reason to delete it).
+  dispatch_once(&key_predicate, ^ {
+    pthread_key_create(&_MSAICrashCXXExceptionInfoTSDKey, free);
+  });
+  
+  OSSpinLockLock(&_MSAICrashCXXExceptionHandlingLock); {
+    if (!_MSAICrashIsOurTerminateHandlerInstalled) {
+      _MSAICrashOriginalTerminateHandler = std::set_terminate(MSAICrashUncaughtCXXTerminateHandler);
+      _MSAICrashIsOurTerminateHandlerInstalled = true;
+    }
+    _MSAICrashUncaughtExceptionHandlerList.push_back(handler);
+  } OSSpinLockUnlock(&_MSAICrashCXXExceptionHandlingLock);
 }
 
 + (void)removeCXXExceptionHandler:(MSAICrashUncaughtCXXExceptionHandler)handler
 {
-    OSSpinLockLock(&_MSAICrashCXXExceptionHandlingLock); {
-        auto i = std::find(_MSAICrashUncaughtExceptionHandlerList.begin(), _MSAICrashUncaughtExceptionHandlerList.end(), handler);
-      
-        if (i != _MSAICrashUncaughtExceptionHandlerList.end()) {
-          _MSAICrashUncaughtExceptionHandlerList.erase(i);
-        }
+  OSSpinLockLock(&_MSAICrashCXXExceptionHandlingLock); {
+    auto i = std::find(_MSAICrashUncaughtExceptionHandlerList.begin(), _MSAICrashUncaughtExceptionHandlerList.end(), handler);
     
-        if (_MSAICrashIsOurTerminateHandlerInstalled) {
-            if (_MSAICrashUncaughtExceptionHandlerList.empty()) {
-                std::terminate_handler previous_handler = std::set_terminate(_MSAICrashOriginalTerminateHandler);
-                
-                if (previous_handler != MSAICrashUncaughtCXXTerminateHandler) {
-                    std::set_terminate(previous_handler);
-                } else {
-                    _MSAICrashIsOurTerminateHandlerInstalled = false;
-                    _MSAICrashOriginalTerminateHandler = nullptr;
-                }
-            }
+    if (i != _MSAICrashUncaughtExceptionHandlerList.end()) {
+      _MSAICrashUncaughtExceptionHandlerList.erase(i);
+    }
+    
+    if (_MSAICrashIsOurTerminateHandlerInstalled) {
+      if (_MSAICrashUncaughtExceptionHandlerList.empty()) {
+        std::terminate_handler previous_handler = std::set_terminate(_MSAICrashOriginalTerminateHandler);
+        
+        if (previous_handler != MSAICrashUncaughtCXXTerminateHandler) {
+          std::set_terminate(previous_handler);
+        } else {
+          _MSAICrashIsOurTerminateHandlerInstalled = false;
+          _MSAICrashOriginalTerminateHandler = nullptr;
         }
-    } OSSpinLockUnlock(&_MSAICrashCXXExceptionHandlingLock);
+      }
+    }
+  } OSSpinLockUnlock(&_MSAICrashCXXExceptionHandlingLock);
 }
 
 @end


### PR DESCRIPTION
Statically overload __cxa_throw() to capture backtraces from C++ exceptions at throw time. Makes reasonable best efforts at speed.

Remove meaningless namespace qualifier from throw override. Look up the Objective-C exception vtable dynamically (since weak import doesn't do what you think, even when it does). Remove useless debugging statements that were just causing trouble.